### PR TITLE
III-1273: Fix object object bug, and still work in ie11 and minified

### DIFF
--- a/app/scripts/url-shim.js
+++ b/app/scripts/url-shim.js
@@ -1,9 +1,9 @@
 try {
     new URL('http://uitdatabank.be');
 } catch (e) {
-    function URL (uri) {
+    URL = function (uri) {
         this.uri = uri;
-    }
+    };
 
     URL.prototype = {
         toString: function () {


### PR DESCRIPTION
Due to minification the function definition for the shim for IE11 was
moved outside the catch-block. This can be even replayed using online
minification websites.