### PR TITLE
III-1267: Fix session token error

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -42,12 +42,6 @@ angular
       $location,
       uitidAuth
     ) {
-      $rootScope.$watch(function () {
-        return uitidAuth.getToken();
-      }, function (token) {
-        udbApi.getMe();
-      });
-
       amMoment.changeLocale('nl');
 
       $rootScope.$on('searchSubmitted', function () {

--- a/app/scripts/controllers/app.js
+++ b/app/scripts/controllers/app.js
@@ -12,7 +12,7 @@ angular
   .controller('AppCtrl', AppController);
 
 /* @ngInject */
-function AppController($location, uitidAuth) {
+function AppController($location, uitidAuth, udbApi) {
   var controller = this;
 
   function parseJwtToken () {
@@ -22,9 +22,11 @@ function AppController($location, uitidAuth) {
     if (jwt && jwt !== uitidAuth.getToken()) {
       uitidAuth.setToken(jwt);
       $location.search('jwt', null);
+      udbApi.getMe();
+      // TODO: Emit event here that user was logged in, and also when logged out
     }
   }
 
   controller.$onInit = parseJwtToken;
 }
-AppController.$inject = ['$location', 'uitidAuth'];
+AppController.$inject = ['$location', 'uitidAuth', 'udbApi'];


### PR DESCRIPTION
Every time when rootScope get's altered the $rootScope.$watch(fn ..
get's executed. But this was required to make sure the right user is
fetched after a login. Instead it's better to fetch a user after they
logged in.