### PR TITLE
III-2962 - added exportTemplateUrl and exportTemplateTypes in config.…

### DIFF
--- a/config.json.dist
+++ b/config.json.dist
@@ -73,6 +73,11 @@
       {"name": "uitpas", "label": "UiTPAS", "logo": "uitpas.svg"},
       {"name": "paspartoe", "label": "Paspartoe", "logo": "paspartoe.svg"}
   ],
+  "exportTemplateUrl": "https://udb3-export-template.s3.amazonaws.com/",
+  "exportTemplateTypes": [
+    {"name": "tips", "label": "Tipsrapport", "img": "tips.svg"},
+    {"name": "map", "label": "Weergave op kaart (beta)", "img": "map.svg"}
+  ],
   "restrictedExportBrands": [],
   "publicationUrl": {
     "event": "https://www.uitinvlaanderen.be/agenda/e//",


### PR DESCRIPTION
### Added
- added exportTemplateUrl with path to aws image bucket (udb3-export-template)
 - added exportTemplateTypes in appConfig with the 2 different template types (tips and maps). With the keys name, label and image
