### PR TITLE
Change management.users.edit route parameters

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -463,7 +463,7 @@ function udbAppConfig(
       }
     })
     .state('management.users.edit', {
-      url: '/manage/users/:id',
+      url: '/manage/users/:email',
       templateUrl: 'templates/user-editor.html',
       controller: 'UserEditorController',
       controllerAs: 'editor',


### PR DESCRIPTION
### Changed

- Changed `management.users.edit` route to use an `email` parameter instead of `id`

---
Ticket: https://jira.uitdatabank.be/browse/III-3203