### PR TITLE
III-3357 Change the current language if the url has a lang parameter

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -41,6 +41,8 @@ angular
     '$rootScope',
     '$location',
     '$window',
+    '$cookies',
+    '$translate',
     'uitidAuth',
     'ngMeta',
     'migrationRedirect',
@@ -51,12 +53,21 @@ angular
       $rootScope,
       $location,
       $window,
+      $cookies,
+      $translate,
       uitidAuth,
       ngMeta,
       migrationRedirect,
       tmhDynamicLocale
     ) {
       amMoment.changeLocale('nl');
+
+      var queryStringParams = new URLSearchParams($location.search());
+      if (queryStringParams.has('lang')) {
+        var language = queryStringParams.get('lang');
+        $cookies.put('udb-language', language);
+        $translate.use(language);
+      }
 
       ngMeta.init();
 
@@ -71,6 +82,7 @@ angular
 
         var queryStringParams = new URLSearchParams($location.search());
         queryStringParams.delete('jwt');
+        queryStringParams.delete('lang');
 
         var queryString = queryStringParams.toString();
         var path = $location.path() + (queryString ? '?' + queryString : '');


### PR DESCRIPTION
### Added

- Added check for `lang` parameter in URL to set the current language

---

Notes: Required for https://github.com/cultuurnet/udb3-frontend/pull/3, as the `udb-language` cookie will not be shared when not running on `localhost` but on e.g. `www.uitdatabank.be` and `old.uitdatabank.be`