### PR TITLE
III-3397 Add option to redirect to Vue app when running outside of an iframe

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -24,7 +24,6 @@
     <!-- endbuild -->
 
     <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,300,400,700,600' rel='stylesheet' type='text/css'>
-    <base href="/">
   </head>
   <body>
   <udb-app class="overlay-static-elements">

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -37,6 +37,7 @@ angular
   /* @ngInject */
   .run([
     'udbApi',
+    'appConfig',
     'amMoment',
     '$rootScope',
     '$location',
@@ -49,6 +50,7 @@ angular
     'tmhDynamicLocale',
     function (
       udbApi,
+      appConfig,
       amMoment,
       $rootScope,
       $location,
@@ -61,6 +63,12 @@ angular
       tmhDynamicLocale
     ) {
       amMoment.changeLocale('nl');
+
+      var runningInIframe = window !== window.parent;
+      var needsToRunInIframe = appConfig.redirectToVueWhenNotInIframe;
+      if (!runningInIframe && needsToRunInIframe) {
+        $window.location.href = appConfig.baseUrlVueApp + $location.url();
+      }
 
       var queryStringParams = new URLSearchParams($location.search());
       if (queryStringParams.has('lang')) {

--- a/config.json.dist
+++ b/config.json.dist
@@ -111,5 +111,7 @@
     "defaultApi": "udb3"
   },
   "created_by_query_mode": "mixed",
-  "hideRegister": true
+  "hideRegister": true,
+  "redirectToVueWhenNotInIframe": true,
+  "baseUrlVueApp": "http://localhost:3000"
 }


### PR DESCRIPTION
### Added

- Added option to redirect to the Vue app when running outside of an iframe. So when the user is working in the Vue app and opens a link in the iframe in a new tab, it redirects to the same path in the Vue app in the new tab. And also to disable direct traffic to the AngularJS app in general once we're running the Vue app in production.

---
Ticket: https://jira.uitdatabank.be/browse/III-3397

---
Note: We tried using the `<base>` tag first to make all links link to the Vue URL when running the AngularJS app in an iframe, but then all styles, scripts and image paths would also change to the Vue URL and the AngularJS app would thus break.