### PR TITLE
III-5397 - Change branding colors to match new sidebar design

### DIFF
--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -23,6 +23,9 @@
 
 // styling for rounded / 2022 look
 body {
+
+  background-color: #F5F5F5 !important;
+
   button,
   a,
   input,
@@ -311,3 +314,5 @@ body {
 
 
 }
+
+

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -70,13 +70,13 @@ body {
 
 
   ul.pagination  > .active > a {
-    background-color: #00AAE5 !important;
-    border-color: #00AAE5 !important;
+    background-color: #0083B8 !important;
+    border-color: #0083B8 !important;
   }
 
   ul.pagination > li > a:hover {
-    background-color: #00AAE5 !important;
-    border-color: #00AAE5 !important;
+    background-color: #005C7C !important;
+    border-color: #005C7C !important;
   }
 
   .nav-tabs {
@@ -245,10 +245,69 @@ body {
   }
 
   .btn-primary {
-    background-color: #00AAE5 !important;
+    background-color: #0083B8 !important;
+  }
+
+  .btn-primary:hover {
+    background-color: #005C7C !important;
   }
 
   .dropdown-menu > .active > a {
-    background-color: #00AAE5 !important;
+    background-color: #0083B8 !important;
   }
+
+  .alert {
+    position: relative;
+    color: #141515 !important;
+
+    &::before {
+      position: absolute;
+      content: '';
+      top: 0;
+      left: 0;
+      width: 6px;
+      height: 100%;
+      display: block;
+      border-top-left-radius: 8px;
+      border-bottom-left-radius: 8px;
+    }
+  }
+
+  .alert-info {
+    background-color:#D1DEFA !important;
+    border-color: #3868EC !important;
+
+    &::before {
+      background-color:#3868EC;
+    }
+  }
+
+  .alert-danger {
+    background-color: #FAE5E3 !important;
+    border-color: #DD5242 !important;
+
+    &::before {
+      background-color: #DD5242 !important;
+    }
+  }
+
+  .alert-success {
+    background-color: #F3FCF7 !important;
+    border-color: #6BCD69 !important;
+
+    &::before {
+      background-color:#6BCD69 !important;
+    }
+  }
+
+  .alert-warning {
+    background-color: #FCF0CB !important;
+    border-color: #F5B041 !important;
+
+    &::before {
+      background-color:#F5B041 !important;
+    }
+  }
+
+
 }

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -68,6 +68,17 @@ body {
     border-bottom-right-radius: 8px !important;
   }
 
+
+  ul.pagination  > .active > a {
+    background-color: #00AAE5 !important;
+    border-color: #00AAE5 !important;
+  }
+
+  ul.pagination > li > a:hover {
+    background-color: #00AAE5 !important;
+    border-color: #00AAE5 !important;
+  }
+
   .nav-tabs {
     li[role="tab"] a {
       border-bottom-left-radius: 0 !important;

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -243,4 +243,9 @@ body {
   .udb-query-editor .control-in-uitsluiten > button:first-child {
     margin-right: 0.75rem;
   }
+
+  .btn-primary {
+    background-color: #00AAE5 !important;
+  }
+
 }

--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -248,4 +248,7 @@ body {
     background-color: #00AAE5 !important;
   }
 
+  .dropdown-menu > .active > a {
+    background-color: #00AAE5 !important;
+  }
 }

--- a/app/styles/bootstrap-variables.less
+++ b/app/styles/bootstrap-variables.less
@@ -43,11 +43,10 @@
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-@font-family-sans-serif:  'Open Sans', Helvetica, Arial, sans-serif;
 @font-family-serif:       Georgia, "Times New Roman", Times, serif;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
-@font-family-base:        @font-family-sans-serif;
+@font-family-base:        ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji' !important;
 
 @font-size-base:          15px;
 @font-size-large:         ceil((@font-size-base * 1.25)); // ~18px


### PR DESCRIPTION
### Changed
- branding colors  (btn-primary, typeahead, alerts, pagination items) to match new sidebar design.

<img width="342" alt="Screenshot 2023-11-08 at 11 08 37" src="https://github.com/cultuurnet/udb3-angular-app/assets/9402377/0e3a526d-a690-4b0c-91af-6049689596ea">


<img width="1253" alt="Screenshot 2023-11-08 at 11 08 44" src="https://github.com/cultuurnet/udb3-angular-app/assets/9402377/469ca8bf-c0f6-4059-85b4-31f4403855cf">

-------
Ticket:
[https://jira.uitdatabank.be/browse/III-5851](https://jira.uitdatabank.be/browse/III-5851)